### PR TITLE
[patch] skip empty message being appended while preparing error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -86,18 +86,21 @@ func (e *Error) Error() string {
 // which are not of type *Error
 func (e *Error) Message() string {
 	messages := make([]string, 0, 5)
-	messages = append(messages, e.message)
+	if e.message != "" {
+		messages = append(messages, e.message)
+	}
 
 	err, _ := e.original.(*Error)
 	for err != nil {
 		if err.message == "" {
+			err, _ = err.original.(*Error)
 			continue
 		}
 		messages = append(messages, err.message)
 		err, _ = err.original.(*Error)
 	}
 
-	if len(messages) > 1 {
+	if len(messages) > 0 {
 		return strings.Join(messages, ". ")
 	}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -220,3 +220,71 @@ func Benchmark_HTTPStatusCodeMessage(b *testing.B) {
 		_, _, _ = HTTPStatusCodeMessage(err)
 	}
 }
+
+func TestError_Message(t *testing.T) {
+	type fields struct {
+		original error
+		message  string
+		eType    errType
+		fileLine string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "No nested error",
+			fields: fields{
+				original: nil,
+				message:  "hello friendly error msg",
+				eType:    TypeInternal,
+				fileLine: "errors.go:87",
+			},
+			want: "hello friendly error msg",
+		},
+		{
+			name: "Empty message",
+			fields: fields{
+				original: nil,
+				message:  "",
+				eType:    TypeInternal,
+				fileLine: "errors.go:87",
+			},
+			want: "",
+		},
+		{
+			name: "Nested error with message",
+			fields: fields{
+				original: &Error{
+					original: &Error{
+						message:  "",
+						eType:    TypeInputBody,
+						fileLine: "errors.go:87",
+					},
+					message:  "hello nested err message",
+					eType:    TypeInternal,
+					fileLine: "errors.go:87",
+				},
+				message:  "",
+				eType:    TypeInternal,
+				fileLine: "errors.go:87",
+			},
+			want: "hello nested err message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Error{
+				original: tt.fields.original,
+				message:  tt.fields.message,
+				eType:    tt.fields.eType,
+				fileLine: tt.fields.fileLine,
+			}
+			if got := e.Message(); got != tt.want {
+				t.Errorf("Error.Message() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[patch] fixed bug where Message() would go into an infinite loop if a nested error has empty message
[patch] updated tests for Message()

closes #1 