### PR TITLE
[minor] `Stacktrace(err error) string` - returns a prettified stacktr…

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -58,6 +59,7 @@ type Error struct {
 	// Type is used to define the type of the error, e.g. Server error, validation error etc.
 	eType    errType
 	fileLine string
+	pcs      []uintptr
 }
 
 // Error is the implementation of error interface
@@ -93,11 +95,9 @@ func (e *Error) ErrorWithoutFileLine() string {
 	}
 
 	if e.message != "" {
-		// string concatenation with + is ~100x faster than fmt.Sprintf()
 		return e.message
 	}
 
-	// string concatenation with + is ~100x faster than fmt.Sprintf()
 	return e.fileLine
 }
 
@@ -134,7 +134,7 @@ func (e *Error) Unwrap() error {
 // Is implements the Is interface required by Go
 func (e *Error) Is(err error) bool {
 	o, _ := err.(*Error)
-	return o != nil && o == e
+	return o == e
 }
 
 // HTTPStatusCode is a convenience method used to get the appropriate HTTP response status code for the respective error type
@@ -192,7 +192,7 @@ func (e *Error) Type() errType {
 	return e.eType
 }
 
-// Format implements the verbs supported by Error to be used in fmt annotated/formatted strings
+// Format implements the verbs/directives supported by Error to be used in fmt annotated/formatted strings
 /*
 %v  - the same output as Message(). i.e. recursively get all the custom messages set by user
     - if any of the wrapped error is not of type *Error, that will *not* be displayed
@@ -203,42 +203,188 @@ non *Error types.
 %+s - recursively prints all the messages without file & line number. Also includes output `Error()` of
 non *Error types.
 */
-
 func (e *Error) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			io.WriteString(s, e.Error())
+			_, _ = io.WriteString(s, e.Error())
 		} else {
-			io.WriteString(s, e.Message())
+			_, _ = io.WriteString(s, e.Message())
 		}
 	case 's':
 		{
 			if s.Flag('+') {
-				io.WriteString(s, e.ErrorWithoutFileLine())
+				_, _ = io.WriteString(s, e.ErrorWithoutFileLine())
 			} else {
-				io.WriteString(s, e.Message())
+				_, _ = io.WriteString(s, e.Message())
 			}
 		}
 	}
 }
 
+func (e *Error) RuntimeFrames() *runtime.Frames {
+	return runtime.CallersFrames(e.pcs)
+}
+
+func (e *Error) ProgramCounters() []uintptr {
+	return e.pcs
+}
+
+func (e *Error) StackTrace() string {
+	trace := make([]string, 0, 100)
+	rframes := e.RuntimeFrames()
+	frame, ok := rframes.Next()
+	line := strconv.Itoa(frame.Line)
+	trace = append(trace, frame.Function+"(): "+e.message)
+	for ok {
+		trace = append(trace, "\t"+frame.File+":"+line)
+		frame, ok = rframes.Next()
+	}
+	return strings.Join(trace, "\n")
+}
+
+func (e *Error) StackTraceNoFormat() []string {
+	trace := make([]string, 0, 100)
+	rframes := e.RuntimeFrames()
+	frame, ok := rframes.Next()
+	line := strconv.Itoa(frame.Line)
+	trace = append(trace, frame.Function+"(): "+e.message)
+	for ok {
+		trace = append(trace, frame.File+":"+line)
+		frame, ok = rframes.Next()
+	}
+	return trace
+}
+
+// StackTraceCustomFormat lets you prepare a stacktrace in a custom format
+/*
+Supported directives:
+%m - message
+%p - file path
+%l - line
+%f - function
+*/
+func (e *Error) StackTraceCustomFormat(msgformat string, traceFormat string) string {
+	rframes := e.RuntimeFrames()
+	frame, ok := rframes.Next()
+
+	message := strings.ReplaceAll(msgformat, "%m", e.message)
+	message = strings.ReplaceAll(message, "%p", frame.File)
+	message = strings.ReplaceAll(message, "%l", strconv.Itoa(frame.Line))
+	message = strings.ReplaceAll(message, "%f", frame.Function)
+	traces := make([]string, 0, 100)
+	traces = append(traces, message)
+
+	for ok {
+		trace := strings.ReplaceAll(traceFormat, "%m", e.message)
+		trace = strings.ReplaceAll(trace, "%p", frame.File)
+		trace = strings.ReplaceAll(trace, "%l", strconv.Itoa(frame.Line))
+		trace = strings.ReplaceAll(trace, "%f", frame.Function)
+
+		traces = append(traces, trace)
+		frame, ok = rframes.Next()
+	}
+
+	return strings.Join(traces, "")
+}
+
 // New returns a new instance of Error with the relavant fields initialized
 func New(msg string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, msg, file, line, defaultErrType)
+	return newerr(nil, msg, defaultErrType)
 }
 
 func Newf(fromat string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, defaultErrType, fromat, args...)
+	return newerrf(nil, defaultErrType, fromat, args...)
 }
+
+// Errorf is a convenience method to create a new instance of Error with formatted message
+// Important: %w directive is not supported, use fmt.Errorf if you're using the %w directive or
+// use Wrap/Wrapf to wrap an error.
 func Errorf(fromat string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, defaultErrType, fromat, args...)
+	return Newf(fromat, args...)
 }
 
 // SetDefaultType will set the default error type, which is used in the 'New' function
 func SetDefaultType(e errType) {
 	defaultErrType = e
+}
+
+// Stacktrace returns a string representation of the stacktrace, where each trace is separated by a newline and tab '\t'
+func Stacktrace(err error) string {
+	trace := make([]string, 0, 100)
+	for err != nil {
+		e, ok := err.(*Error)
+		if ok {
+			trace = append(trace, e.StackTrace())
+		} else {
+			trace = append(trace, err.Error())
+		}
+		err = Unwrap(err)
+	}
+	return strings.Join(trace, "\n")
+}
+
+// Stacktrace returns a string representation of the stacktrace, as a slice of string where each
+// element represents the error message and traces.
+func StacktraceNoFormat(err error) []string {
+	trace := make([]string, 0, 100)
+	for err != nil {
+		e, ok := err.(*Error)
+		if ok {
+			trace = append(trace, e.StackTraceNoFormat()...)
+		} else {
+			trace = append(trace, err.Error())
+		}
+		err = Unwrap(err)
+	}
+	return trace
+}
+
+// StacktraceCustomFormat lets you prepare a stacktrace in a custom format
+/*
+msgformat - is used to format the line which prints message from Error.message
+traceFormat - is used to format the line which prints trace
+Supported directives:
+%m - message if err type is *Error, otherwise output of `.Error()`
+%p - file path, empty if type is not *Error
+%l - line, empty if type is not *Error
+%f - function, empty if type is not *Error
+*/
+func StacktraceCustomFormat(msgformat string, traceFormat string, err error) string {
+	trace := make([]string, 0, 100)
+	for err != nil {
+		e, ok := err.(*Error)
+		if ok {
+			trace = append(trace, e.StackTraceCustomFormat(msgformat, traceFormat))
+		} else {
+			message := strings.ReplaceAll(msgformat, "%m", err.Error())
+			message = strings.ReplaceAll(message, "%p", "")
+			message = strings.ReplaceAll(message, "%l", "")
+			message = strings.ReplaceAll(message, "%f", "")
+
+			trace = append(
+				trace,
+				message,
+			)
+		}
+		err = Unwrap(err)
+	}
+	return strings.Join(trace, "")
+}
+
+func ProgramCounters(err error) []uintptr {
+	pcs := make([]uintptr, 0, 100)
+	for err != nil {
+		e, ok := err.(*Error)
+		if ok {
+			pcs = append(pcs, e.ProgramCounters()...)
+		}
+		err = Unwrap(err)
+	}
+	return pcs
+}
+
+func RuntimeFrames(err error) *runtime.Frames {
+	pcs := ProgramCounters(err)
+	return runtime.CallersFrames(pcs)
 }

--- a/errors_benchmark_test.go
+++ b/errors_benchmark_test.go
@@ -1,0 +1,81 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func Benchmark_Internal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Internal("hello world")
+	}
+}
+func Benchmark_Internalf(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Internalf("%s prefixed", "hello world")
+	}
+}
+
+func Benchmark_InternalErr(b *testing.B) {
+	err := errors.New("bad error")
+	for i := 0; i < b.N; i++ {
+		_ = InternalErr(err, "hello world")
+	}
+}
+
+func Benchmark_InternalGetError(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Internal("hello world").Error()
+	}
+}
+func Benchmark_InternalGetErrorWithNestedError(b *testing.B) {
+	err := errors.New("bad error")
+	for i := 0; i < b.N; i++ {
+		_ = InternalErr(err, "hello world").Error()
+	}
+}
+
+func Benchmark_InternalGetMessage(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Internal("hello world").Message()
+	}
+}
+
+func Benchmark_InternalGetMessageWithNestedError(b *testing.B) {
+	err := New("bad error")
+	for i := 0; i < b.N; i++ {
+		_ = InternalErr(err, "hello world").Message()
+	}
+}
+
+func Benchmark_HTTPStatusCodeMessage(b *testing.B) {
+	// SubscriptionExpiredErr is the slowest considering it's the last item in switch case
+	err := SubscriptionExpiredErr(SubscriptionExpired("old"), "expired")
+	for i := 0; i < b.N; i++ {
+		_, _, _ = HTTPStatusCodeMessage(err)
+	}
+}
+
+func BenchmarkHasType(b *testing.B) {
+	err := ValidationErr(
+		DuplicateErr(
+			SubscriptionExpiredErr(
+				ValidationErr(
+					InputBodyErr(
+						Internal("hello world"),
+						DefaultMessage,
+					),
+					DefaultMessage,
+				),
+				DefaultMessage,
+			),
+			DefaultMessage,
+		),
+		DefaultMessage,
+	)
+	for i := 0; i < b.N; i++ {
+		if !HasType(err, TypeInternal) {
+			b.Fatal("TypeInternal not found")
+		}
+	}
+}

--- a/helper.go
+++ b/helper.go
@@ -9,340 +9,293 @@ import (
 	"strings"
 )
 
-func newerr(e error, message string, file string, line int, etype errType) *Error {
+func newerr(e error, message string, etype errType) *Error {
+	_, file, line, _ := runtime.Caller(2)
+	pcs := make([]uintptr, 100)
+	_ = runtime.Callers(3, pcs)
 	return &Error{
 		original: e,
 		message:  message,
 		eType:    etype,
 		// '+' concatenation is ~100x faster than using fmt.Sprintf("%s:%d", file, line)
 		fileLine: file + ":" + strconv.Itoa(line),
+		pcs:      pcs,
 	}
 }
 
-func newerrf(e error, file string, line int, etype errType, format string, args ...interface{}) *Error {
+func newerrf(e error, etype errType, format string, args ...interface{}) *Error {
 	message := fmt.Sprintf(format, args...)
-	return newerr(e, message, file, line, etype)
+	return newerr(e, message, etype)
 }
 
-// Wrap is used to simply wrap an error with no custom error message with Error struct; with the error
-// type being defaulted to `TypeInternal`
+// Wrap is used to simply wrap an error with optional message; error type would be the
+// default error type set using SetDefaultType; TypeInternal otherwise
 // If the error being wrapped is already of type Error, then its respective type is used
 func Wrap(original error, msg ...string) *Error {
 	message := strings.Join(msg, ". ")
-	_, file, line, _ := runtime.Caller(1)
 	e, _ := original.(*Error)
 	if e == nil {
-		return newerr(original, message, file, line, TypeInternal)
+		return newerr(original, message, TypeInternal)
 	}
-	return newerr(original, message, file, line, e.eType)
+	return newerr(original, message, e.eType)
 }
 
 func Wrapf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
 	e, _ := original.(*Error)
 	if e == nil {
-		return newerrf(original, file, line, TypeInternal, format, args...)
+		return newerrf(original, TypeInternal, format, args...)
 	}
-	return newerrf(original, file, line, e.Type(), format, args...)
+	return newerrf(original, e.Type(), format, args...)
 }
 
-// WrapWithMsg [deprecated, use `Wrap`] wrap error with a user friendly message
+// Deprecated: WrapWithMsg [deprecated, use `Wrap`] wrap error with a user friendly message
 func WrapWithMsg(original error, msg string) *Error {
-	_, file, line, _ := runtime.Caller(1)
 	e, _ := original.(*Error)
 	if e == nil {
-		return newerr(original, msg, file, line, TypeInternal)
+		return newerr(original, msg, TypeInternal)
 	}
-	return newerr(original, msg, file, line, e.eType)
+	return newerr(original, msg, e.eType)
 }
 
 // NewWithType returns an error instance with custom error type
 func NewWithType(msg string, etype errType) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, msg, file, line, etype)
+	return newerr(nil, msg, etype)
 }
 
 // NewWithTypef returns an error instance with custom error type. And formatted message
 func NewWithTypef(etype errType, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, etype, format, args...)
+	return newerrf(nil, etype, format, args...)
 }
 
 // NewWithErrMsgType returns an error instance with custom error type and message
 func NewWithErrMsgType(original error, message string, etype errType) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, etype)
+	return newerr(original, message, etype)
 }
 
 // NewWithErrMsgTypef returns an error instance with custom error type and formatted message
 func NewWithErrMsgTypef(original error, etype errType, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, etype, format, args...)
+	return newerrf(original, etype, format, args...)
 }
 
 // Internal helper method for creating internal errors
 func Internal(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeInternal)
+	return newerr(nil, message, TypeInternal)
 }
 
 // Internalf helper method for creating internal errors with formatted message
 func Internalf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeInternal, format, args...)
+	return newerrf(nil, TypeInternal, format, args...)
 }
 
 // Validation is a helper function to create a new error of type TypeValidation
 func Validation(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeValidation)
+	return newerr(nil, message, TypeValidation)
 }
 
 // Validationf is a helper function to create a new error of type TypeValidation, with formatted message
 func Validationf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeValidation, format, args...)
+	return newerrf(nil, TypeValidation, format, args...)
 }
 
 // InputBody is a helper function to create a new error of type TypeInputBody
 func InputBody(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeInputBody)
+	return newerr(nil, message, TypeInputBody)
 }
 
 // InputBodyf is a helper function to create a new error of type TypeInputBody, with formatted message
 func InputBodyf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeInputBody, format, args...)
+	return newerrf(nil, TypeInputBody, format, args...)
 }
 
 // Duplicate is a helper function to create a new error of type TypeDuplicate
 func Duplicate(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeDuplicate)
+	return newerr(nil, message, TypeDuplicate)
 }
 
 // Duplicatef is a helper function to create a new error of type TypeDuplicate, with formatted message
 func Duplicatef(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeDuplicate, format, args...)
+	return newerrf(nil, TypeDuplicate, format, args...)
 }
 
 // Unauthenticated is a helper function to create a new error of type TypeUnauthenticated
 func Unauthenticated(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeUnauthenticated)
+	return newerr(nil, message, TypeUnauthenticated)
 }
 
 // Unauthenticatedf is a helper function to create a new error of type TypeUnauthenticated, with formatted message
 func Unauthenticatedf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeUnauthenticated, format, args...)
+	return newerrf(nil, TypeUnauthenticated, format, args...)
 
 }
 
 // Unauthorized is a helper function to create a new error of type TypeUnauthorized
 func Unauthorized(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeUnauthorized)
+	return newerr(nil, message, TypeUnauthorized)
 }
 
 // Unauthorizedf is a helper function to create a new error of type TypeUnauthorized, with formatted message
 func Unauthorizedf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeUnauthorized, format, args...)
+	return newerrf(nil, TypeUnauthorized, format, args...)
 }
 
 // Empty is a helper function to create a new error of type TypeEmpty
 func Empty(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeEmpty)
+	return newerr(nil, message, TypeEmpty)
 }
 
 // Emptyf is a helper function to create a new error of type TypeEmpty, with formatted message
 func Emptyf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeEmpty, format, args...)
+	return newerrf(nil, TypeEmpty, format, args...)
 }
 
 // NotFound is a helper function to create a new error of type TypeNotFound
 func NotFound(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeNotFound)
+	return newerr(nil, message, TypeNotFound)
 }
 
 // NotFoundf is a helper function to create a new error of type TypeNotFound, with formatted message
 func NotFoundf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeNotFound, format, args...)
+	return newerrf(nil, TypeNotFound, format, args...)
 }
 
 // MaximumAttempts is a helper function to create a new error of type TypeMaximumAttempts
 func MaximumAttempts(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeMaximumAttempts)
+	return newerr(nil, message, TypeMaximumAttempts)
 }
 
 // MaximumAttemptsf is a helper function to create a new error of type TypeMaximumAttempts, with formatted message
 func MaximumAttemptsf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeMaximumAttempts, format, args...)
+	return newerrf(nil, TypeMaximumAttempts, format, args...)
 }
 
 // SubscriptionExpired is a helper function to create a new error of type TypeSubscriptionExpired
 func SubscriptionExpired(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeSubscriptionExpired)
+	return newerr(nil, message, TypeSubscriptionExpired)
 }
 
 // SubscriptionExpiredf is a helper function to create a new error of type TypeSubscriptionExpired, with formatted message
 func SubscriptionExpiredf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeSubscriptionExpired, format, args...)
+	return newerrf(nil, TypeSubscriptionExpired, format, args...)
 }
 
 // DownstreamDependencyTimedout is a helper function to create a new error of type TypeDownstreamDependencyTimedout
 func DownstreamDependencyTimedout(message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(nil, message, file, line, TypeDownstreamDependencyTimedout)
+	return newerr(nil, message, TypeDownstreamDependencyTimedout)
 }
 
 // DownstreamDependencyTimedoutf is a helper function to create a new error of type TypeDownstreamDependencyTimedout, with formatted message
 func DownstreamDependencyTimedoutf(format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(nil, file, line, TypeDownstreamDependencyTimedout, format, args...)
+	return newerrf(nil, TypeDownstreamDependencyTimedout, format, args...)
 }
 
 // InternalErr helper method for creation internal errors which also accepts an original error
 func InternalErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeInternal)
+	return newerr(original, message, TypeInternal)
 }
 
 // InternalErr helper method for creation internal errors which also accepts an original error, with formatted message
 func InternalErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeInternal, format, args...)
+	return newerrf(original, TypeInternal, format, args...)
 }
 
 // ValidationErr helper method for creation validation errors which also accepts an original error
 func ValidationErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeValidation)
+	return newerr(original, message, TypeValidation)
 }
 
 // ValidationErr helper method for creation validation errors which also accepts an original error, with formatted message
 func ValidationErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeValidation, format, args...)
+	return newerrf(original, TypeValidation, format, args...)
 }
 
 // InputBodyErr is a helper function to create a new error of type TypeInputBody which also accepts an original error
 func InputBodyErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeInputBody)
+	return newerr(original, message, TypeInputBody)
 }
 
 // InputBodyErrf is a helper function to create a new error of type TypeInputBody which also accepts an original error, with formatted message
 func InputBodyErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeInputBody, format, args...)
+	return newerrf(original, TypeInputBody, format, args...)
 }
 
 // DuplicateErr is a helper function to create a new error of type TypeDuplicate which also accepts an original error
 func DuplicateErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeDuplicate)
+	return newerr(original, message, TypeDuplicate)
 }
 
 // DuplicateErrf is a helper function to create a new error of type TypeDuplicate which also accepts an original error, with formatted message
 func DuplicateErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeDuplicate, format, args...)
+	return newerrf(original, TypeDuplicate, format, args...)
 }
 
 // UnauthenticatedErr is a helper function to create a new error of type TypeUnauthenticated which also accepts an original error
 func UnauthenticatedErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeUnauthenticated)
+	return newerr(original, message, TypeUnauthenticated)
 }
 
 // UnauthenticatedErrf is a helper function to create a new error of type TypeUnauthenticated which also accepts an original error, with formatted message
 func UnauthenticatedErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeUnauthenticated, format, args...)
+	return newerrf(original, TypeUnauthenticated, format, args...)
 }
 
 // UnauthorizedErr is a helper function to create a new error of type TypeUnauthorized which also accepts an original error
 func UnauthorizedErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeUnauthorized)
+	return newerr(original, message, TypeUnauthorized)
 }
 
 // UnauthorizedErrf is a helper function to create a new error of type TypeUnauthorized which also accepts an original error, with formatted message
 func UnauthorizedErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeUnauthorized, format, args...)
+	return newerrf(original, TypeUnauthorized, format, args...)
 }
 
 // EmptyErr is a helper function to create a new error of type TypeEmpty which also accepts an original error
 func EmptyErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeEmpty)
+	return newerr(original, message, TypeEmpty)
 }
 
 // EmptyErr is a helper function to create a new error of type TypeEmpty which also accepts an original error, with formatted message
 func EmptyErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeEmpty, format, args...)
+	return newerrf(original, TypeEmpty, format, args...)
 }
 
 // NotFoundErr is a helper function to create a new error of type TypeNotFound which also accepts an original error
 func NotFoundErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeNotFound)
+	return newerr(original, message, TypeNotFound)
 }
 
 // NotFoundErrf is a helper function to create a new error of type TypeNotFound which also accepts an original error, with formatted message
 func NotFoundErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeNotFound, format, args...)
+	return newerrf(original, TypeNotFound, format, args...)
 }
 
 // MaximumAttemptsErr is a helper function to create a new error of type TypeMaximumAttempts which also accepts an original error
 func MaximumAttemptsErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeMaximumAttempts)
+	return newerr(original, message, TypeMaximumAttempts)
 }
 
 // MaximumAttemptsErr is a helper function to create a new error of type TypeMaximumAttempts which also accepts an original error, with formatted message
 func MaximumAttemptsErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeMaximumAttempts, format, args...)
+	return newerrf(original, TypeMaximumAttempts, format, args...)
 }
 
 // SubscriptionExpiredErr is a helper function to create a new error of type TypeSubscriptionExpired which also accepts an original error
 func SubscriptionExpiredErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeSubscriptionExpired)
+	return newerr(original, message, TypeSubscriptionExpired)
 }
 
 // SubscriptionExpiredErrf is a helper function to create a new error of type TypeSubscriptionExpired which also accepts an original error, with formatted message
 func SubscriptionExpiredErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeSubscriptionExpired, format, args...)
+	return newerrf(original, TypeSubscriptionExpired, format, args...)
 }
 
 // DownstreamDependencyTimedoutErr is a helper function to create a new error of type TypeDownstreamDependencyTimedout which also accepts an original error
 func DownstreamDependencyTimedoutErr(original error, message string) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerr(original, message, file, line, TypeDownstreamDependencyTimedout)
+	return newerr(original, message, TypeDownstreamDependencyTimedout)
 }
 
 // DownstreamDependencyTimedoutErrf is a helper function to create a new error of type TypeDownstreamDependencyTimedout which also accepts an original error, with formatted message
 func DownstreamDependencyTimedoutErrf(original error, format string, args ...interface{}) *Error {
-	_, file, line, _ := runtime.Caller(1)
-	return newerrf(original, file, line, TypeDownstreamDependencyTimedout, format, args...)
+	return newerrf(original, TypeDownstreamDependencyTimedout, format, args...)
 }
 
 // HTTPStatusCodeMessage returns the appropriate HTTP status code, message, boolean for the error
@@ -354,6 +307,16 @@ func HTTPStatusCodeMessage(err error) (int, string, bool) {
 	}
 
 	return http.StatusInternalServerError, err.Error(), false
+}
+
+// HTTPStatusCode returns appropriate HTTP response status code based on type of the error. The boolean
+// is 'true' if the provided error is of type *Err
+func HTTPStatusCode(err error) (int, bool) {
+	derr, _ := err.(*Error)
+	if derr != nil {
+		return derr.HTTPStatusCode(), true
+	}
+	return http.StatusInternalServerError, false
 }
 
 // ErrWithoutTrace is a duplicate of Message, but with clearer name. The boolean is 'true' if the
@@ -370,16 +333,6 @@ func Message(err error) (string, bool) {
 		return derr.Message(), true
 	}
 	return "", false
-}
-
-// HTTPStatusCode returns appropriate HTTP response status code based on type of the error. The boolean
-// is 'true' if the provided error is of type *Err
-func HTTPStatusCode(err error) (int, bool) {
-	derr, _ := err.(*Error)
-	if derr != nil {
-		return derr.HTTPStatusCode(), true
-	}
-	return 0, false
 }
 
 // WriteHTTP is a convenience method which will check if the error is of type *Error and


### PR DESCRIPTION
[minor] `Stacktrace(err error) string` - returns a prettified stacktrace of the error
[minor] `StacktraceCustomFormat(msgformat string, traceFormat string, err error) string` - supports using custom format
[minor] `RuntimeFrames(err error)` - returns *runtime.Frames* of the error, based on combined (if nested) program counters of the error
[minor] `ProgramCounters(err error) []uintptr` - returns combined (if nested) program counters of the error
[minor] fmt.Formatter interface implementation