### PR TITLE
Stacktrace fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://godoc.org/github.com/nathany/looper?status.svg)](https://pkg.go.dev/github.com/bnkamalesh/errors?tab=doc)
 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#error-handling)
 
-# Errors v0.9.1
+# Errors v0.9.3
 
 Errors package is a drop-in replacement of the built-in Go errors package. It lets you create errors of 11 different types,
 which should handle most of the use cases. Some of them are a bit too specific for web applications, but useful nonetheless.

--- a/README.md
+++ b/README.md
@@ -7,19 +7,22 @@
 [![](https://godoc.org/github.com/nathany/looper?status.svg)](https://pkg.go.dev/github.com/bnkamalesh/errors?tab=doc)
 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#error-handling)
 
-# Errors v0.9.0
+# Errors v0.9.1
 
-Errors package is a drop-in replacement of the built-in Go errors package with no external dependencies. It lets you create errors of 11 different types which should handle most of the use cases. Some of them are a bit too specific for web applications, but useful nonetheless. Following are the primary features of this package:
+Errors package is a drop-in replacement of the built-in Go errors package. It lets you create errors of 11 different types,
+which should handle most of the use cases. Some of them are a bit too specific for web applications, but useful nonetheless.
+
+Features of this package:
 
 1. Multiple (11) error types
-2. User friendly message
+2. Easy handling of User friendly message(s)
 3. Stacktrace - formatted, unfromatted, custom format (refer tests in errors_test.go)
-4. Retrieve the Program Counters, for compatibility external libraries which generate their own stacktrace
-5. Retrieve *runtime.Frames using `errors.RuntimeFrames(err error)`, for compatibility external libraries which generate their own stacktrace
+4. Retrieve the Program Counters for the stacktrace
+5. Retrieve runtime.Frames using `errors.RuntimeFrames(err error)` for the stacktrace
 6. HTTP status code and user friendly message (wrapped messages are concatenated) for all error types
 7. Helper functions to generate each error type
 8. Helper function to get error Type, error type as int, check if error type is wrapped anywhere in chain
-9. fmt.Formatter support
+9. `fmt.Formatter` support
 
 In case of nested errors, the messages & errors are also looped through the full chain of errors.
 
@@ -29,27 +32,31 @@ Go 1.13+
 
 ### Available error types
 
-1. TypeInternal - is the error type for when there is an internal system error. e.g. Database errors
-2. TypeValidation - is the error type for when there is a validation error. e.g. invalid email address
-3. TypeInputBody - is the error type for when the input data is invalid. e.g. invalid JSON
-4. TypeDuplicate - is the error type for when there's duplicate content. e.g. user with email already exists (when trying to register a new user)
-5. TypeUnauthenticated - is the error type when trying to access an authenticated API without authentication
-6. TypeUnauthorized - is the error type for when there's an unauthorized access attempt
-7. TypeEmpty - is the error type for when an expected non-empty resource, is empty
-8. TypeNotFound - is the error type for an expected resource is not found. e.g. user ID not found
-9. TypeMaximumAttempts - is the error type for attempting the same action more than an allowed threshold
-10. TypeSubscriptionExpired - is the error type for when a user's 'paid' account has expired
-11. TypeDownstreamDependencyTimedout - is the error type for when a request to a downstream dependent service times out
+1. TypeInternal - For internal system error. e.g. Database errors
+2. TypeValidation - For validation error. e.g. invalid email address
+3. TypeInputBody - For invalid input data. e.g. invalid JSON
+4. TypeDuplicate - For duplicate content error. e.g. user with email already exists (when trying to register a new user)
+5. TypeUnauthenticated - For not authenticated error
+6. TypeUnauthorized - For unauthorized access error
+7. TypeEmpty - For when an expected non-empty resource, is empty
+8. TypeNotFound - For expected resource not found. e.g. user ID not found
+9. TypeMaximumAttempts - For attempting the same action more than an allowed threshold
+10. TypeSubscriptionExpired - For when a user's 'paid' account has expired
+11. TypeDownstreamDependencyTimedout - For when a request to a downstream dependent service times out
 
-Helper functions are available for all the error types. Each of them have 2 helper functions, one which accepts only a string, and the other which accepts an original error as well as a user friendly message.
+Helper functions are available for all the error types. Each of them have 2 helper functions, one which accepts only a string,
+and the other which accepts an original error as well as a user friendly message.
 
-All the dedicated error type functions are documented [here](https://pkg.go.dev/github.com/bnkamalesh/errors?tab=doc#DownstreamDependencyTimedout). Names are consistent with the error type, e.g. errors.Internal(string) and errors.InternalErr(error, string)
+All the dedicated error type functions are documented [here](https://pkg.go.dev/github.com/bnkamalesh/errors?tab=doc#DownstreamDependencyTimedout).
+Names are consistent with the error type, e.g. errors.Internal(string) and errors.InternalErr(error, string)
 
 ### User friendly messages
 
-More often than not, when writing APIs, we'd want to respond with an easier to undersand user friendly message. Instead of returning the raw error. And log the raw error.
+More often than not when writing APIs, we'd want to respond with an easier to undersand user friendly message.
+Instead of returning the raw error and log the raw error.
 
-There are helper functions for all the error types, when in need of setting a friendly message, there are helper functions have a suffix 'Err'. All such helper functions accept the original error and a string.
+There are helper functions for all the error types. When in need of setting a friendly message, there
+are helper functions with the _suffix_ **'Err'**. All such helper functions accept the original error and a string.
 
 ```golang
 package main
@@ -74,7 +81,7 @@ func Foo() error {
 
 func main() {
 	err := Foo()
-	
+
 	fmt.Println("err:", err)
 	fmt.Println("\nerr.Error():", err.Error())
 
@@ -88,15 +95,16 @@ func main() {
 }
 ```
 
-Output 
+Output
+
 ```
 err: bar is not happy
 
-err.Error(): /path/to/file.go:16: bar is not happy
-hello world!
+err.Error(): /Users/k.balakumaran/go/src/github.com/bnkamalesh/errors/cmd/main.go:16: bar is not happy
+hello world!bar is not happy
 
-formatted +v: /path/to/file.go:16: bar is not happy
-hello world!
+formatted +v: /Users/k.balakumaran/go/src/github.com/bnkamalesh/errors/cmd/main.go:16: bar is not happy
+hello world!bar is not happy
 
 formatted v: bar is not happy
 
@@ -115,7 +123,7 @@ A common annoyance with Go errors which most people are aware of is, figuring ou
 
 ### HTTP status code & message
 
-The function `errors.HTTPStatusCodeMessage(error) (int, string, bool)` returns the HTTP status code, message, and a boolean value. The boolean is true, if the error is of type *Error from this package. If error is nested, it unwraps and returns a single concatenated message. Sample described in the 'How to use?' section
+The function `errors.HTTPStatusCodeMessage(error) (int, string, bool)` returns the HTTP status code, message, and a boolean value. The boolean is true, if the error is of type \*Error from this package. If error is nested, it unwraps and returns a single concatenated message. Sample described in the 'How to use?' section
 
 ## How to use?
 
@@ -196,47 +204,51 @@ func main() {
 
 ```
 
-[webgo](https://github.com/bnkamalesh/webgo) was used to illustrate the usage of the function, `errors.HTTPStatusCodeMessage`. It returns the appropriate http status code, user friendly message stored within, and a boolean value. Boolean value is `true` if the returned error of type *Error.
-Since we get the status code and message separately, when using any web framework, you can set values according to the respective framework's native functions. In case of Webgo, it wraps errors in a struct of its own. Otherwise, you could directly respond to the HTTP request by calling `errors.WriteHTTP(error,http.ResponseWriter)`. 
+[webgo](https://github.com/bnkamalesh/webgo) was used to illustrate the usage of the function, `errors.HTTPStatusCodeMessage`. It returns the appropriate http status code, user friendly message stored within, and a boolean value. Boolean value is `true` if the returned error of type \*Error.
+Since we get the status code and message separately, when using any web framework, you can set values according to the respective framework's native functions. In case of Webgo, it wraps errors in a struct of its own. Otherwise, you could directly respond to the HTTP request by calling `errors.WriteHTTP(error,http.ResponseWriter)`.
 
 Once the app is running, you can check the response by opening `http://localhost:8080` on your browser. Or on terminal
+
 ```bash
 $ curl http://localhost:8080
 {"errors":"we lost bar2!. bar2 was deceived by bar1 :(","status":500} // output
 ```
 
 And the `fmt.Println(err.Error())` generated output on stdout would be:
+
 ```bash
 /Users/username/go/src/errorscheck/main.go:28 /Users/username/go/src/errorscheck/main.go:20 sinking bar
 ```
 
-## Benchmark [2021-12-13]
+## Benchmark [2022-01-12]
+
+MacBook Pro (13-inch, 2020, Four Thunderbolt 3 ports), 32 GB 3733 MHz LPDDR4X
 
 ```bash
 $ go version
-go version go1.17.4 linux/amd64
+go version go1.19.5 darwin/amd64
 
 $ go test -benchmem -bench .
-goos: linux
+goos: darwin
 goarch: amd64
 pkg: github.com/bnkamalesh/errors
-cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
-Benchmark_Internal-8                             772088       1412 ns/op    1272 B/op    5 allocs/op
-Benchmark_Internalf-8                            695674       1692 ns/op    1296 B/op    6 allocs/op
-Benchmark_InternalErr-8                          822500       1404 ns/op    1272 B/op    5 allocs/op
-Benchmark_InternalGetError-8                     881791       1319 ns/op    1368 B/op    6 allocs/op
-Benchmark_InternalGetErrorWithNestedError-8      712803       1488 ns/op    1384 B/op    6 allocs/op
-Benchmark_InternalGetMessage-8                   927864       1237 ns/op    1272 B/op    5 allocs/op
-Benchmark_InternalGetMessageWithNestedError-8    761164       1675 ns/op    1296 B/op    6 allocs/op
-Benchmark_HTTPStatusCodeMessage-8                29116684     41.62 ns/op   16 B/op      1 allocs/op
-BenchmarkHasType-8                               100000000    11.50 ns/op   0 B/op       0 allocs/op
+cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
+Benchmark_Internal-8                            	 1526194	       748.8 ns/op	    1104 B/op	       2 allocs/op
+Benchmark_Internalf-8                           	 1281465	       944.0 ns/op	    1128 B/op	       3 allocs/op
+Benchmark_InternalErr-8                         	 1494351	       806.7 ns/op	    1104 B/op	       2 allocs/op
+Benchmark_InternalGetError-8                    	  981162	      1189 ns/op	    1528 B/op	       6 allocs/op
+Benchmark_InternalGetErrorWithNestedError-8     	  896322	      1267 ns/op	    1544 B/op	       6 allocs/op
+Benchmark_InternalGetMessage-8                  	 1492812	       804.2 ns/op	    1104 B/op	       2 allocs/op
+Benchmark_InternalGetMessageWithNestedError-8   	 1362092	       886.3 ns/op	    1128 B/op	       3 allocs/op
+Benchmark_HTTPStatusCodeMessage-8               	27494096	        41.38 ns/op	      16 B/op	       1 allocs/op
+BenchmarkHasType-8                              	100000000	        10.50 ns/op	       0 B/op	       0 allocs/op
 PASS
-ok  	github.com/bnkamalesh/errors	10.604s
+ok  	github.com/bnkamalesh/errors	15.006s
 ```
 
 ## Contributing
 
-More error types, customization, features etc; PRs & issues are welcome!
+More error types, customization, features, multi-errors; PRs & issues are welcome!
 
 ## The gopher
 

--- a/errors.go
+++ b/errors.go
@@ -234,10 +234,9 @@ func (e *Error) StackTrace() string {
 	trace := make([]string, 0, 100)
 	rframes := e.RuntimeFrames()
 	frame, ok := rframes.Next()
-	line := strconv.Itoa(frame.Line)
 	trace = append(trace, frame.Function+"(): "+e.message)
 	for ok {
-		trace = append(trace, "\t"+frame.File+":"+line)
+		trace = append(trace, "\t"+frame.File+":"+strconv.Itoa(frame.Line))
 		frame, ok = rframes.Next()
 	}
 	return strings.Join(trace, "\n")
@@ -301,7 +300,7 @@ func Newf(fromat string, args ...interface{}) *Error {
 // Important: %w directive is not supported, use fmt.Errorf if you're using the %w directive or
 // use Wrap/Wrapf to wrap an error.
 func Errorf(fromat string, args ...interface{}) *Error {
-	return Newf(fromat, args...)
+	return newerrf(nil, defaultErrType, 3, fromat, args...)
 }
 
 // SetDefaultType will set the default error type, which is used in the 'New' function

--- a/errors.go
+++ b/errors.go
@@ -70,10 +70,12 @@ func (e *Error) fileLine() string {
 
 	frames := runtime.CallersFrames([]uintptr{e.pc + 1})
 	frame, _ := frames.Next()
+
 	buff := bytes.NewBuffer(make([]byte, 0, 100))
 	buff.WriteString(frame.File)
 	buff.WriteString(":")
 	buff.WriteString(strconv.Itoa(frame.Line))
+
 	return buff.String()
 }
 
@@ -247,7 +249,7 @@ func (e *Error) Format(s fmt.State, verb rune) {
 }
 
 func (e *Error) RuntimeFrames() *runtime.Frames {
-	return runtime.CallersFrames(e.pcs)
+	return runtime.CallersFrames(e.ProgramCounters())
 }
 
 func (e *Error) ProgramCounters() []uintptr {

--- a/errors.go
+++ b/errors.go
@@ -255,13 +255,14 @@ func (e *Error) ProgramCounters() []uintptr {
 }
 
 func (e *Error) StackTrace() string {
-	trace := make([]string, 0, 100)
 	rframes := e.RuntimeFrames()
 	frame, ok := rframes.Next()
 	buff := bytes.NewBuffer(make([]byte, 0, 100))
 	buff.WriteString(frame.Function)
 	buff.WriteString("(): ")
 	buff.WriteString(e.message)
+
+	trace := make([]string, 0, len(e.ProgramCounters()))
 	trace = append(trace, buff.String())
 	for ok {
 		buff.Reset()
@@ -276,7 +277,6 @@ func (e *Error) StackTrace() string {
 }
 
 func (e *Error) StackTraceNoFormat() []string {
-	trace := make([]string, 0, 100)
 	rframes := e.RuntimeFrames()
 	frame, ok := rframes.Next()
 	line := strconv.Itoa(frame.Line)
@@ -286,6 +286,7 @@ func (e *Error) StackTraceNoFormat() []string {
 	buff.WriteString("(): ")
 	buff.WriteString(e.message)
 
+	trace := make([]string, 0, len(e.ProgramCounters()))
 	trace = append(trace, buff.String())
 	for ok {
 		buff.Reset()
@@ -314,7 +315,7 @@ func (e *Error) StackTraceCustomFormat(msgformat string, traceFormat string) str
 	message = strings.ReplaceAll(message, "%p", frame.File)
 	message = strings.ReplaceAll(message, "%l", strconv.Itoa(frame.Line))
 	message = strings.ReplaceAll(message, "%f", frame.Function)
-	traces := make([]string, 0, 100)
+	traces := make([]string, 0, len(e.ProgramCounters()))
 	traces = append(traces, message)
 
 	for ok {
@@ -332,18 +333,18 @@ func (e *Error) StackTraceCustomFormat(msgformat string, traceFormat string) str
 
 // New returns a new instance of Error with the relavant fields initialized
 func New(msg string) *Error {
-	return newerr(nil, msg, defaultErrType, 2)
+	return newerr(nil, msg, defaultErrType, 3)
 }
 
 func Newf(fromat string, args ...interface{}) *Error {
-	return newerrf(nil, defaultErrType, 3, fromat, args...)
+	return newerrf(nil, defaultErrType, 4, fromat, args...)
 }
 
 // Errorf is a convenience method to create a new instance of Error with formatted message
 // Important: %w directive is not supported, use fmt.Errorf if you're using the %w directive or
 // use Wrap/Wrapf to wrap an error.
 func Errorf(fromat string, args ...interface{}) *Error {
-	return newerrf(nil, defaultErrType, 3, fromat, args...)
+	return newerrf(nil, defaultErrType, 4, fromat, args...)
 }
 
 // SetDefaultType will set the default error type, which is used in the 'New' function

--- a/errors.go
+++ b/errors.go
@@ -471,7 +471,7 @@ func StacktraceCustomFormat(msgformat string, traceFormat string, err error) str
 		final = append(final, list...)
 	}
 
-	return strings.Join(final, "\n")
+	return strings.Join(final, "")
 }
 
 func ProgramCounters(err error) []uintptr {

--- a/errors.go
+++ b/errors.go
@@ -70,29 +70,33 @@ func (e *Error) fileLine() string {
 
 	frames := runtime.CallersFrames([]uintptr{e.pc + 1})
 	frame, _ := frames.Next()
-	return frame.File + ":" + strconv.Itoa(frame.Line)
+	buff := bytes.NewBuffer(make([]byte, 0, 100))
+	buff.WriteString(frame.File)
+	buff.WriteString(":")
+	buff.WriteString(strconv.Itoa(frame.Line))
+	return buff.String()
 }
 
 // Error is the implementation of error interface
 func (e *Error) Error() string {
-	fline := e.fileLine()
-	fl := bytes.NewBuffer(make([]byte, 0, len(fline)))
-	if fline != "" {
-		fl.Write([]byte(fline))
-		fl.Write([]byte(": "))
+	fl := bytes.NewBuffer(make([]byte, 0, 100))
+	fl.WriteString(e.fileLine())
+	if fl.Len() != 0 {
+		fl.WriteString(": ")
 	}
 
 	if e.original != nil {
-		fl.Write([]byte(e.message))
-		fl.Write([]byte("\n"))
-		fl.Write([]byte(e.original.Error()))
+		fl.WriteString(e.message)
+		fl.WriteString("\n")
+		fl.WriteString(e.original.Error())
 	}
 
 	if e.message != "" {
-		fl.Write([]byte(e.message))
-	} else {
-		fl.Write([]byte(DefaultMessage))
+		fl.WriteString(e.message)
+		return fl.String()
 	}
+
+	fl.WriteString(DefaultMessage)
 
 	return fl.String()
 }
@@ -101,12 +105,13 @@ func (e *Error) Error() string {
 func (e *Error) ErrorWithoutFileLine() string {
 	if e.original != nil {
 		if e.message != "" {
-			msg := bytes.NewBuffer([]byte(e.message))
-			msg.Write([]byte(": "))
+			msg := bytes.NewBuffer(make([]byte, 0, 100))
+			msg.WriteString(e.message)
+			msg.WriteString(": ")
 			if o, ok := e.original.(*Error); ok {
-				msg.Write([]byte(o.ErrorWithoutFileLine()))
+				msg.WriteString(o.ErrorWithoutFileLine())
 			} else {
-				msg.Write([]byte(e.original.Error()))
+				msg.WriteString(e.original.Error())
 			}
 			return msg.String()
 		}
@@ -254,16 +259,16 @@ func (e *Error) StackTrace() string {
 	rframes := e.RuntimeFrames()
 	frame, ok := rframes.Next()
 	buff := bytes.NewBuffer(make([]byte, 0, 100))
-	buff.Write([]byte(frame.Function))
-	buff.Write([]byte("(): "))
-	buff.Write([]byte(e.message))
+	buff.WriteString(frame.Function)
+	buff.WriteString("(): ")
+	buff.WriteString(e.message)
 	trace = append(trace, buff.String())
 	for ok {
 		buff.Reset()
-		buff.Write([]byte("\t"))
-		buff.Write([]byte(frame.File))
-		buff.Write([]byte(":"))
-		buff.Write([]byte(strconv.Itoa(frame.Line)))
+		buff.WriteString("\t")
+		buff.WriteString(frame.File)
+		buff.WriteString(":")
+		buff.WriteString(strconv.Itoa(frame.Line))
 		trace = append(trace, buff.String())
 		frame, ok = rframes.Next()
 	}
@@ -276,17 +281,17 @@ func (e *Error) StackTraceNoFormat() []string {
 	frame, ok := rframes.Next()
 	line := strconv.Itoa(frame.Line)
 
-	buff := bytes.NewBuffer(make([]byte, 0, len(e.message)))
-	buff.Write([]byte(frame.Function))
-	buff.Write([]byte("(): "))
-	buff.Write([]byte(e.message))
+	buff := bytes.NewBuffer(make([]byte, 0, 100))
+	buff.WriteString(frame.Function)
+	buff.WriteString("(): ")
+	buff.WriteString(e.message)
 
 	trace = append(trace, buff.String())
 	for ok {
 		buff.Reset()
-		buff.Write([]byte(frame.File))
-		buff.Write([]byte(":"))
-		buff.Write([]byte(line))
+		buff.WriteString(frame.File)
+		buff.WriteString(":")
+		buff.WriteString(line)
 		trace = append(trace, buff.String())
 		frame, ok = rframes.Next()
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -93,7 +93,7 @@ func TestNew(t *testing.T) {
 	}
 	e := New(message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 
 	if !reflect.DeepEqual(*e, want) {
 		t.Errorf("New() = %v\nwant %v", *e, want)
@@ -109,7 +109,7 @@ func TestErrorf(t *testing.T) {
 	}
 	e := Errorf(format, message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 
 	if !reflect.DeepEqual(*e, want) {
 		t.Fail()

--- a/helper.go
+++ b/helper.go
@@ -9,9 +9,8 @@ import (
 )
 
 func newerr(e error, message string, etype errType, skip int) *Error {
-
 	pcs := make([]uintptr, 128)
-	_ = runtime.Callers(skip+1, pcs)
+	_ = runtime.Callers(skip, pcs)
 	return &Error{
 		original: e,
 		message:  message,
@@ -39,257 +38,257 @@ func getErrType(err error) errType {
 // If the error being wrapped is already of type Error, then its respective type is used
 func Wrap(original error, msg ...string) *Error {
 	message := strings.Join(msg, ". ")
-	return newerr(original, message, getErrType(original), 2)
+	return newerr(original, message, getErrType(original), 3)
 }
 
 func Wrapf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, getErrType(original), 3, format, args...)
+	return newerrf(original, getErrType(original), 4, format, args...)
 }
 
 // Deprecated: WrapWithMsg [deprecated, use `Wrap`] wrap error with a user friendly message
 func WrapWithMsg(original error, msg string) *Error {
-	return newerr(original, msg, getErrType(original), 2)
+	return newerr(original, msg, getErrType(original), 3)
 }
 
 // NewWithType returns an error instance with custom error type
 func NewWithType(msg string, etype errType) *Error {
-	return newerr(nil, msg, etype, 2)
+	return newerr(nil, msg, etype, 3)
 }
 
 // NewWithTypef returns an error instance with custom error type. And formatted message
 func NewWithTypef(etype errType, format string, args ...interface{}) *Error {
-	return newerrf(nil, etype, 3, format, args...)
+	return newerrf(nil, etype, 4, format, args...)
 }
 
 // NewWithErrMsgType returns an error instance with custom error type and message
 func NewWithErrMsgType(original error, message string, etype errType) *Error {
-	return newerr(original, message, etype, 2)
+	return newerr(original, message, etype, 3)
 }
 
 // NewWithErrMsgTypef returns an error instance with custom error type and formatted message
 func NewWithErrMsgTypef(original error, etype errType, format string, args ...interface{}) *Error {
-	return newerrf(original, etype, 3, format, args...)
+	return newerrf(original, etype, 4, format, args...)
 }
 
 // Internal helper method for creating internal errors
 func Internal(message string) *Error {
-	return newerr(nil, message, TypeInternal, 2)
+	return newerr(nil, message, TypeInternal, 3)
 }
 
 // Internalf helper method for creating internal errors with formatted message
 func Internalf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeInternal, 3, format, args...)
+	return newerrf(nil, TypeInternal, 4, format, args...)
 }
 
 // Validation is a helper function to create a new error of type TypeValidation
 func Validation(message string) *Error {
-	return newerr(nil, message, TypeValidation, 2)
+	return newerr(nil, message, TypeValidation, 3)
 }
 
 // Validationf is a helper function to create a new error of type TypeValidation, with formatted message
 func Validationf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeValidation, 3, format, args...)
+	return newerrf(nil, TypeValidation, 4, format, args...)
 }
 
 // InputBody is a helper function to create a new error of type TypeInputBody
 func InputBody(message string) *Error {
-	return newerr(nil, message, TypeInputBody, 2)
+	return newerr(nil, message, TypeInputBody, 3)
 }
 
 // InputBodyf is a helper function to create a new error of type TypeInputBody, with formatted message
 func InputBodyf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeInputBody, 3, format, args...)
+	return newerrf(nil, TypeInputBody, 4, format, args...)
 }
 
 // Duplicate is a helper function to create a new error of type TypeDuplicate
 func Duplicate(message string) *Error {
-	return newerr(nil, message, TypeDuplicate, 2)
+	return newerr(nil, message, TypeDuplicate, 3)
 }
 
 // Duplicatef is a helper function to create a new error of type TypeDuplicate, with formatted message
 func Duplicatef(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeDuplicate, 3, format, args...)
+	return newerrf(nil, TypeDuplicate, 4, format, args...)
 }
 
 // Unauthenticated is a helper function to create a new error of type TypeUnauthenticated
 func Unauthenticated(message string) *Error {
-	return newerr(nil, message, TypeUnauthenticated, 2)
+	return newerr(nil, message, TypeUnauthenticated, 3)
 }
 
 // Unauthenticatedf is a helper function to create a new error of type TypeUnauthenticated, with formatted message
 func Unauthenticatedf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeUnauthenticated, 3, format, args...)
+	return newerrf(nil, TypeUnauthenticated, 4, format, args...)
 
 }
 
 // Unauthorized is a helper function to create a new error of type TypeUnauthorized
 func Unauthorized(message string) *Error {
-	return newerr(nil, message, TypeUnauthorized, 2)
+	return newerr(nil, message, TypeUnauthorized, 3)
 }
 
 // Unauthorizedf is a helper function to create a new error of type TypeUnauthorized, with formatted message
 func Unauthorizedf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeUnauthorized, 3, format, args...)
+	return newerrf(nil, TypeUnauthorized, 4, format, args...)
 }
 
 // Empty is a helper function to create a new error of type TypeEmpty
 func Empty(message string) *Error {
-	return newerr(nil, message, TypeEmpty, 2)
+	return newerr(nil, message, TypeEmpty, 3)
 }
 
 // Emptyf is a helper function to create a new error of type TypeEmpty, with formatted message
 func Emptyf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeEmpty, 3, format, args...)
+	return newerrf(nil, TypeEmpty, 4, format, args...)
 }
 
 // NotFound is a helper function to create a new error of type TypeNotFound
 func NotFound(message string) *Error {
-	return newerr(nil, message, TypeNotFound, 2)
+	return newerr(nil, message, TypeNotFound, 3)
 }
 
 // NotFoundf is a helper function to create a new error of type TypeNotFound, with formatted message
 func NotFoundf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeNotFound, 3, format, args...)
+	return newerrf(nil, TypeNotFound, 4, format, args...)
 }
 
 // MaximumAttempts is a helper function to create a new error of type TypeMaximumAttempts
 func MaximumAttempts(message string) *Error {
-	return newerr(nil, message, TypeMaximumAttempts, 2)
+	return newerr(nil, message, TypeMaximumAttempts, 3)
 }
 
 // MaximumAttemptsf is a helper function to create a new error of type TypeMaximumAttempts, with formatted message
 func MaximumAttemptsf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeMaximumAttempts, 3, format, args...)
+	return newerrf(nil, TypeMaximumAttempts, 4, format, args...)
 }
 
 // SubscriptionExpired is a helper function to create a new error of type TypeSubscriptionExpired
 func SubscriptionExpired(message string) *Error {
-	return newerr(nil, message, TypeSubscriptionExpired, 2)
+	return newerr(nil, message, TypeSubscriptionExpired, 3)
 }
 
 // SubscriptionExpiredf is a helper function to create a new error of type TypeSubscriptionExpired, with formatted message
 func SubscriptionExpiredf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeSubscriptionExpired, 3, format, args...)
+	return newerrf(nil, TypeSubscriptionExpired, 4, format, args...)
 }
 
 // DownstreamDependencyTimedout is a helper function to create a new error of type TypeDownstreamDependencyTimedout
 func DownstreamDependencyTimedout(message string) *Error {
-	return newerr(nil, message, TypeDownstreamDependencyTimedout, 2)
+	return newerr(nil, message, TypeDownstreamDependencyTimedout, 3)
 }
 
 // DownstreamDependencyTimedoutf is a helper function to create a new error of type TypeDownstreamDependencyTimedout, with formatted message
 func DownstreamDependencyTimedoutf(format string, args ...interface{}) *Error {
-	return newerrf(nil, TypeDownstreamDependencyTimedout, 3, format, args...)
+	return newerrf(nil, TypeDownstreamDependencyTimedout, 4, format, args...)
 }
 
 // InternalErr helper method for creation internal errors which also accepts an original error
 func InternalErr(original error, message string) *Error {
-	return newerr(original, message, TypeInternal, 2)
+	return newerr(original, message, TypeInternal, 3)
 }
 
 // InternalErr helper method for creation internal errors which also accepts an original error, with formatted message
 func InternalErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeInternal, 3, format, args...)
+	return newerrf(original, TypeInternal, 4, format, args...)
 }
 
 // ValidationErr helper method for creation validation errors which also accepts an original error
 func ValidationErr(original error, message string) *Error {
-	return newerr(original, message, TypeValidation, 2)
+	return newerr(original, message, TypeValidation, 3)
 }
 
 // ValidationErr helper method for creation validation errors which also accepts an original error, with formatted message
 func ValidationErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeValidation, 3, format, args...)
+	return newerrf(original, TypeValidation, 4, format, args...)
 }
 
 // InputBodyErr is a helper function to create a new error of type TypeInputBody which also accepts an original error
 func InputBodyErr(original error, message string) *Error {
-	return newerr(original, message, TypeInputBody, 2)
+	return newerr(original, message, TypeInputBody, 3)
 }
 
 // InputBodyErrf is a helper function to create a new error of type TypeInputBody which also accepts an original error, with formatted message
 func InputBodyErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeInputBody, 3, format, args...)
+	return newerrf(original, TypeInputBody, 4, format, args...)
 }
 
 // DuplicateErr is a helper function to create a new error of type TypeDuplicate which also accepts an original error
 func DuplicateErr(original error, message string) *Error {
-	return newerr(original, message, TypeDuplicate, 2)
+	return newerr(original, message, TypeDuplicate, 3)
 }
 
 // DuplicateErrf is a helper function to create a new error of type TypeDuplicate which also accepts an original error, with formatted message
 func DuplicateErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeDuplicate, 3, format, args...)
+	return newerrf(original, TypeDuplicate, 4, format, args...)
 }
 
 // UnauthenticatedErr is a helper function to create a new error of type TypeUnauthenticated which also accepts an original error
 func UnauthenticatedErr(original error, message string) *Error {
-	return newerr(original, message, TypeUnauthenticated, 2)
+	return newerr(original, message, TypeUnauthenticated, 3)
 }
 
 // UnauthenticatedErrf is a helper function to create a new error of type TypeUnauthenticated which also accepts an original error, with formatted message
 func UnauthenticatedErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeUnauthenticated, 3, format, args...)
+	return newerrf(original, TypeUnauthenticated, 4, format, args...)
 }
 
 // UnauthorizedErr is a helper function to create a new error of type TypeUnauthorized which also accepts an original error
 func UnauthorizedErr(original error, message string) *Error {
-	return newerr(original, message, TypeUnauthorized, 2)
+	return newerr(original, message, TypeUnauthorized, 3)
 }
 
 // UnauthorizedErrf is a helper function to create a new error of type TypeUnauthorized which also accepts an original error, with formatted message
 func UnauthorizedErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeUnauthorized, 3, format, args...)
+	return newerrf(original, TypeUnauthorized, 4, format, args...)
 }
 
 // EmptyErr is a helper function to create a new error of type TypeEmpty which also accepts an original error
 func EmptyErr(original error, message string) *Error {
-	return newerr(original, message, TypeEmpty, 2)
+	return newerr(original, message, TypeEmpty, 3)
 }
 
 // EmptyErr is a helper function to create a new error of type TypeEmpty which also accepts an original error, with formatted message
 func EmptyErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeEmpty, 3, format, args...)
+	return newerrf(original, TypeEmpty, 4, format, args...)
 }
 
 // NotFoundErr is a helper function to create a new error of type TypeNotFound which also accepts an original error
 func NotFoundErr(original error, message string) *Error {
-	return newerr(original, message, TypeNotFound, 2)
+	return newerr(original, message, TypeNotFound, 3)
 }
 
 // NotFoundErrf is a helper function to create a new error of type TypeNotFound which also accepts an original error, with formatted message
 func NotFoundErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeNotFound, 3, format, args...)
+	return newerrf(original, TypeNotFound, 4, format, args...)
 }
 
 // MaximumAttemptsErr is a helper function to create a new error of type TypeMaximumAttempts which also accepts an original error
 func MaximumAttemptsErr(original error, message string) *Error {
-	return newerr(original, message, TypeMaximumAttempts, 2)
+	return newerr(original, message, TypeMaximumAttempts, 3)
 }
 
 // MaximumAttemptsErr is a helper function to create a new error of type TypeMaximumAttempts which also accepts an original error, with formatted message
 func MaximumAttemptsErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeMaximumAttempts, 3, format, args...)
+	return newerrf(original, TypeMaximumAttempts, 4, format, args...)
 }
 
 // SubscriptionExpiredErr is a helper function to create a new error of type TypeSubscriptionExpired which also accepts an original error
 func SubscriptionExpiredErr(original error, message string) *Error {
-	return newerr(original, message, TypeSubscriptionExpired, 2)
+	return newerr(original, message, TypeSubscriptionExpired, 3)
 }
 
 // SubscriptionExpiredErrf is a helper function to create a new error of type TypeSubscriptionExpired which also accepts an original error, with formatted message
 func SubscriptionExpiredErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeSubscriptionExpired, 3, format, args...)
+	return newerrf(original, TypeSubscriptionExpired, 4, format, args...)
 }
 
 // DownstreamDependencyTimedoutErr is a helper function to create a new error of type TypeDownstreamDependencyTimedout which also accepts an original error
 func DownstreamDependencyTimedoutErr(original error, message string) *Error {
-	return newerr(original, message, TypeDownstreamDependencyTimedout, 2)
+	return newerr(original, message, TypeDownstreamDependencyTimedout, 3)
 }
 
 // DownstreamDependencyTimedoutErrf is a helper function to create a new error of type TypeDownstreamDependencyTimedout which also accepts an original error, with formatted message
 func DownstreamDependencyTimedoutErrf(original error, format string, args ...interface{}) *Error {
-	return newerrf(original, TypeDownstreamDependencyTimedout, 3, format, args...)
+	return newerrf(original, TypeDownstreamDependencyTimedout, 4, format, args...)
 }
 
 // HTTPStatusCodeMessage returns the appropriate HTTP status code, message, boolean for the error

--- a/helper.go
+++ b/helper.go
@@ -9,7 +9,7 @@ import (
 )
 
 func newerr(e error, message string, etype errType, skip int) *Error {
-	pc, _, _, _ := runtime.Caller(skip)
+
 	pcs := make([]uintptr, 128)
 	_ = runtime.Callers(skip+1, pcs)
 	return &Error{
@@ -17,7 +17,7 @@ func newerr(e error, message string, etype errType, skip int) *Error {
 		message:  message,
 		eType:    etype,
 		pcs:      pcs,
-		pc:       pc,
+		pc:       pcs[0] - 1,
 	}
 }
 

--- a/helper.go
+++ b/helper.go
@@ -26,33 +26,29 @@ func newerrf(e error, etype errType, skip int, format string, args ...interface{
 	return newerr(e, message, etype, skip)
 }
 
+func getErrType(err error) errType {
+	e, _ := err.(*Error)
+	if e == nil {
+		return TypeInternal
+	}
+	return e.Type()
+}
+
 // Wrap is used to simply wrap an error with optional message; error type would be the
 // default error type set using SetDefaultType; TypeInternal otherwise
 // If the error being wrapped is already of type Error, then its respective type is used
 func Wrap(original error, msg ...string) *Error {
 	message := strings.Join(msg, ". ")
-	e, _ := original.(*Error)
-	if e == nil {
-		return newerr(original, message, TypeInternal, 2)
-	}
-	return newerr(original, message, e.eType, 2)
+	return newerr(original, message, getErrType(original), 2)
 }
 
 func Wrapf(original error, format string, args ...interface{}) *Error {
-	e, _ := original.(*Error)
-	if e == nil {
-		return newerrf(original, TypeInternal, 3, format, args...)
-	}
-	return newerrf(original, e.Type(), 3, format, args...)
+	return newerrf(original, getErrType(original), 3, format, args...)
 }
 
 // Deprecated: WrapWithMsg [deprecated, use `Wrap`] wrap error with a user friendly message
 func WrapWithMsg(original error, msg string) *Error {
-	e, _ := original.(*Error)
-	if e == nil {
-		return newerr(original, msg, TypeInternal, 2)
-	}
-	return newerr(original, msg, e.eType, 2)
+	return newerr(original, msg, getErrType(original), 2)
 }
 
 // NewWithType returns an error instance with custom error type

--- a/helper.go
+++ b/helper.go
@@ -5,21 +5,19 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
-	"strconv"
 	"strings"
 )
 
 func newerr(e error, message string, etype errType, skip int) *Error {
-	_, file, line, _ := runtime.Caller(skip)
+	pc, _, _, _ := runtime.Caller(skip)
 	pcs := make([]uintptr, 128)
 	_ = runtime.Callers(skip+1, pcs)
 	return &Error{
 		original: e,
 		message:  message,
 		eType:    etype,
-		// '+' concatenation is ~100x faster than using fmt.Sprintf("%s:%d", file, line)
-		fileLine: file + ":" + strconv.Itoa(line),
 		pcs:      pcs,
+		pc:       pc,
 	}
 }
 

--- a/helper.go
+++ b/helper.go
@@ -10,9 +10,9 @@ import (
 )
 
 func newerr(e error, message string, etype errType, skip int) *Error {
-	_, file, line, _ := runtime.Caller(skip)
+	_, file, line, _ := runtime.Caller(0)
 	pcs := make([]uintptr, 128)
-	_ = runtime.Callers(3, pcs)
+	_ = runtime.Callers(skip+1, pcs)
 	return &Error{
 		original: e,
 		message:  message,

--- a/helper.go
+++ b/helper.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newerr(e error, message string, etype errType, skip int) *Error {
-	_, file, line, _ := runtime.Caller(0)
+	_, file, line, _ := runtime.Caller(skip)
 	pcs := make([]uintptr, 128)
 	_ = runtime.Callers(skip+1, pcs)
 	return &Error{

--- a/helper_test.go
+++ b/helper_test.go
@@ -19,7 +19,7 @@ func TestWrap(t *testing.T) {
 	}
 	e := Wrap(err, message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 	if !reflect.DeepEqual(*e, want) {
 		t.Errorf("New() = %v, want %v", *e, want)
 	}
@@ -33,7 +33,7 @@ func TestWrap(t *testing.T) {
 	}
 	e = Wrap(err, message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 	if !reflect.DeepEqual(*e, want) {
 		t.Errorf("New() = %v, want %v", *e, want)
 	}
@@ -49,7 +49,7 @@ func TestWrapf(t *testing.T) {
 	}
 	e := Wrapf(err, format, message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 	if !reflect.DeepEqual(*e, want) {
 		t.Errorf("New() = %v, want %v", *e, want)
 	}
@@ -64,7 +64,7 @@ func TestWrapf(t *testing.T) {
 	}
 	e = Wrapf(err, format, message)
 	e.pcs = nil
-	e.fileLine = ""
+	e.pc = 0
 	if !reflect.DeepEqual(*e, want) {
 		t.Errorf("New() = %v, want %v", *e, want)
 	}
@@ -329,7 +329,6 @@ func TestErrWithoutTrace(t *testing.T) {
 		original error
 		message  string
 		eType    errType
-		fileLine string
 	}
 	tests := []struct {
 		name   string
@@ -342,7 +341,6 @@ func TestErrWithoutTrace(t *testing.T) {
 				original: nil,
 				message:  "hello friendly error msg",
 				eType:    TypeInternal,
-				fileLine: "errors.go:87",
 			},
 			want: "hello friendly error msg",
 		},
@@ -352,26 +350,22 @@ func TestErrWithoutTrace(t *testing.T) {
 				original: nil,
 				message:  "",
 				eType:    TypeInternal,
-				fileLine: "errors.go:87",
 			},
-			want: "errors.go:87: unknown error occurred",
+			want: "unknown error occurred",
 		},
 		{
 			name: "Nested error with message",
 			fields: fields{
 				original: &Error{
 					original: &Error{
-						message:  "",
-						eType:    TypeInputBody,
-						fileLine: "errors.go:87",
+						message: "",
+						eType:   TypeInputBody,
 					},
-					message:  "hello nested err message",
-					eType:    TypeInternal,
-					fileLine: "errors.go:87",
+					message: "hello nested err message",
+					eType:   TypeInternal,
 				},
-				message:  "",
-				eType:    TypeInternal,
-				fileLine: "errors.go:87",
+				message: "",
+				eType:   TypeInternal,
 			},
 			want: "hello nested err message",
 		},
@@ -383,10 +377,9 @@ func TestErrWithoutTrace(t *testing.T) {
 				original: tt.fields.original,
 				message:  tt.fields.message,
 				eType:    tt.fields.eType,
-				fileLine: tt.fields.fileLine,
 			}
 			if got, _ := ErrWithoutTrace(e); got != tt.want {
-				t.Errorf("Error.Message() = %v, want %v", got, tt.want)
+				t.Errorf("Error.ErrWithoutTrace() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -402,7 +395,6 @@ func TestType(t *testing.T) {
 		original error
 		message  string
 		eType    errType
-		fileLine string
 	}
 	tests := []struct {
 		name   string
@@ -423,7 +415,6 @@ func TestType(t *testing.T) {
 				original: tt.fields.original,
 				message:  tt.fields.message,
 				eType:    tt.fields.eType,
-				fileLine: tt.fields.fileLine,
 			}
 			if got := Type(e); got != tt.want {
 				t.Errorf("Error.Type() = %v, want %v", got, tt.want)


### PR DESCRIPTION
[patch] fixed bugs in stacktrace: remove duplicates when there's nested errors
[patch] fixed bugs in stacktrace: invalid trace when using formatted errors or wrapping
[patch] using bytes buffer instead of string concat, fewer memory allocations and is faster
[-] Updated Benchmark: fewer memory allocations, ~35% faster
