### PR TITLE
[minor] new helper method Join

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,46 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  testold:
+    name: "Test with Go 1.13"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.13
+
+      - name: Test
+        run: go test -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /cmd)
+
+  testlatest:
+    name: "Test with default latest Go"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go latest
+        uses: actions/setup-go@v3
+
+      - name: Test
+        run: go test -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /cmd)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,15 +9,15 @@ on:
       - master
 jobs:
   testold:
-    name: "Test with Go 1.13"
+    name: "Test with Go 1.16"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Go 1.13
+      - name: Set up Go 1.16
         uses: actions/setup-go@v3
         with:
-          go-version: 1.13
+          go-version: 1.16
 
       - name: Test
         run: go test -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /cmd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go:
-  - master
-
-script:
-  - go test -mod=vendor -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v /cmd)
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://user-images.githubusercontent.com/1092882/87815217-d864a680-c882-11ea-9c94-24b67f7125fe.png" alt="errors gopher" width="256px"/></p>
 
-[![Build Status](https://travis-ci.org/bnkamalesh/errors.svg?branch=master)](https://travis-ci.org/bnkamalesh/errors)
+[![](https://github.com/bnkamalesh/errors/actions/workflows/tests.yaml/badge.svg)](https://github.com/bnkamalesh/errors/actions/workflows/tests.yaml)
 [![codecov](https://codecov.io/gh/bnkamalesh/errors/branch/master/graph/badge.svg)](https://codecov.io/gh/bnkamalesh/errors)
 [![Go Report Card](https://goreportcard.com/badge/github.com/bnkamalesh/errors)](https://goreportcard.com/report/github.com/bnkamalesh/errors)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a86629ab167695d4db7f/maintainability)](https://codeclimate.com/github/bnkamalesh/errors)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://godoc.org/github.com/nathany/looper?status.svg)](https://pkg.go.dev/github.com/bnkamalesh/errors?tab=doc)
 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#error-handling)
 
-# Errors v0.9.4
+# Errors v0.10.0
 
 Errors package is a drop-in replacement of the built-in Go errors package. It lets you create errors of 11 different types,
 which should handle most of the use cases. Some of them are a bit too specific for web applications, but useful nonetheless.

--- a/errors_test.go
+++ b/errors_test.go
@@ -26,7 +26,7 @@ func TestFormat(t *testing.T) {
 	err := foo()
 
 	got := fmt.Sprintf("%+v", err)
-	want := "github.com/bnkamalesh/errors/errors_test.go:21: bar is not happy\nhello world!"
+	want := "errors/errors_test.go:21: bar is not happy\nhello world!"
 	if !strings.Contains(got, want) {
 		t.Errorf("got %q\nwant %q", got, want)
 	}
@@ -81,7 +81,7 @@ func TestErrorWithoutFileLine(t *testing.T) {
 
 	err = New("")
 	got = err.ErrorWithoutFileLine()
-	if !strings.Contains(got, "github.com/bnkamalesh/errors/errors_test.go:") {
+	if !strings.Contains(got, "errors/errors_test.go:") {
 		t.Errorf("empty error should have fileline: %s", got)
 	}
 }
@@ -154,7 +154,7 @@ func TestStacktrace(t *testing.T) {
 	got := Stacktrace(e)
 	// silly way of verifying the stacktrace is correct, excluding filepaths
 	strings.Contains(got, "errors.TestStacktrace(): wrapped error")
-	strings.Contains(got, "github.com/bnkamalesh/errors/errors_test.go:76")
+	strings.Contains(got, "errors/errors_test.go:76")
 	strings.Contains(got, "original error")
 }
 func TestStacktraceNoFormat(t *testing.T) {
@@ -163,7 +163,7 @@ func TestStacktraceNoFormat(t *testing.T) {
 	got := strings.Join(StacktraceNoFormat(e), "#")
 	// silly way of verifying the stacktrace is correct, excluding filepaths
 	strings.Contains(got, "errors.TestStacktrace(): wrapped error")
-	strings.Contains(got, "github.com/bnkamalesh/errors/errors_test.go:76")
+	strings.Contains(got, "errors/errors_test.go:76")
 	strings.Contains(got, "original error")
 	if strings.Contains(got, "\n") {
 		t.Error("StacktraceNoFormat() should not contain newlines")

--- a/helper.go
+++ b/helper.go
@@ -334,7 +334,7 @@ func WriteHTTP(err error, w http.ResponseWriter) {
 	// INFO: consider sending back "unknown server error" message
 	status, msg, _ := HTTPStatusCodeMessage(err)
 	w.WriteHeader(status)
-	w.Write([]byte(msg))
+	_, _ = w.Write([]byte(msg))
 }
 
 // Type returns the errType if it's an instance of *Error, -1 otherwise

--- a/mirror.go
+++ b/mirror.go
@@ -16,3 +16,47 @@ func Is(err, target error) bool {
 func As(err error, target interface{}) bool {
 	return errors.As(err, target)
 }
+
+// Join returns an error that wraps the given errors.
+// This is the exact implementation of Go v1.20.
+// It will be removed when Go >= v1.20 becomes the LTS version, and would just call the
+// native Join after that.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}

--- a/mirror.go
+++ b/mirror.go
@@ -17,8 +17,8 @@ func As(err error, target interface{}) bool {
 	return errors.As(err, target)
 }
 
-// Join returns an error that wraps the given errors.
-// This is the exact implementation of Go v1.20.
+// Join returns an error that combines all the given errors.
+// This is the exact implementation found in Go v1.20.
 // It will be removed when Go >= v1.20 becomes the LTS version, and would just call the
 // native Join after that.
 func Join(errs ...error) error {

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -121,10 +121,11 @@ func TestAs(t *testing.T) {
 	if !errors.As(err, &target) {
 		t.Error("As() = false, want true")
 	}
+
 	out := target.Error()
 	want := "github.com/bnkamalesh/errors/mirror_test.go:120: type *Error"
 	if !strings.Contains(out, want) {
-		t.Errorf("As() = %s, want %s", out, "xx")
+		t.Errorf("Error() = %s, want %s", out, want)
 	}
 
 }

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -123,7 +123,7 @@ func TestAs(t *testing.T) {
 	}
 
 	out := target.Error()
-	want := "github.com/bnkamalesh/errors/mirror_test.go:120: type *Error"
+	want := "/errors/mirror_test.go:120: type *Error"
 	if !strings.Contains(out, want) {
 		t.Errorf("Error() = %s, want %s", out, want)
 	}


### PR DESCRIPTION
[-] errors.Join is the exact implementation found in Go v1.20. It is mirrored for backward & forward compatibility. Since this package is supposed to be a drop-in replacement of the native errors package.